### PR TITLE
Move endpoints that are on the chatbot-dev server to Buttons/Server Dev (CU-21ghk0x)

### DIFF
--- a/src/utilities/AWSFunctions.js
+++ b/src/utilities/AWSFunctions.js
@@ -1,11 +1,11 @@
 import axios from 'axios'
 
-const chatbotDevURL = process.env.REACT_APP_CHATBOT_DEV_URL
+const BUTTONS_DEV_URL = process.env.REACT_APP_BUTTONS_DEV_URL
 const braveAPIKey = process.env.REACT_APP_BRAVE_API_KEY
 
 // eslint-disable-next-line import/prefer-default-export
 export async function registerLoraButton(deviceEUI, targetName, clickupToken) {
-  const url = `${chatbotDevURL}/aws-device-registration`
+  const url = `${BUTTONS_DEV_URL}/pa/aws-device-registration`
 
   const data = {
     deviceEUI,

--- a/src/utilities/DatabaseFunctions.js
+++ b/src/utilities/DatabaseFunctions.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 
-const CHATBOT_DEV_ENDPOINT = process.env.REACT_APP_CHATBOT_DEV_URL
+const SENSOR_DEV_URL = process.env.REACT_APP_SENSOR_DEV_URL
 
 // eslint-disable-next-line import/prefer-default-export
 export async function getSensorClients(clickupToken) {
@@ -10,7 +10,7 @@ export async function getSensorClients(clickupToken) {
   }
 
   try {
-    const response = await axios.post(`${CHATBOT_DEV_ENDPOINT}/get-sensor-clients`, data)
+    const response = await axios.post(`${SENSOR_DEV_URL}/pa/get-sensor-clients`, data)
     const resultArray = []
     response.data.clients.forEach(client => resultArray.push(client))
     return resultArray
@@ -44,7 +44,7 @@ export async function insertSensorLocation(
   }
 
   try {
-    const response = await axios.post(`${CHATBOT_DEV_ENDPOINT}/create-sensor-location`, data)
+    const response = await axios.post(`${SENSOR_DEV_URL}/pa/create-sensor-location`, data)
     return response.data.message === 'success'
   } catch (err) {
     console.error(err)

--- a/src/utilities/TwilioFunctions.js
+++ b/src/utilities/TwilioFunctions.js
@@ -1,16 +1,10 @@
 const axios = require('axios')
 
-const accountSID = process.env.REACT_APP_TWILIO_SID
-const twilioToken = process.env.REACT_APP_TWILIO_AUTH_TOKEN
-const messagingWebhook = process.env.REACT_APP_TWILIO_BRAVE_WEBHOOK_URL
-const allSensorMessagesSID = process.env.REACT_APP_TWILIO_ALL_SENSOR_MESSAGES_SID
-
-const chatbotDevURL = process.env.REACT_APP_CHATBOT_DEV_URL
+const BUTTONS_DEV_URL = process.env.REACT_APP_BUTTONS_DEV_URL
+const SENSOR_DEV_URL = process.env.REACT_APP_SENSOR_DEV_URL
 const braveAPIKey = process.env.REACT_APP_BRAVE_API_KEY
 
-export async function purchaseSensorTwilioNumberByAreaCode(areaCode, locationID, clickupToken) {
-  const url = `${chatbotDevURL}/sensor-twilio-number`
-
+async function purchaseTwilioNumberByAreaCode(url, areaCode, locationID, clickupToken) {
   const data = {
     areaCode,
     locationID,
@@ -27,21 +21,10 @@ export async function purchaseSensorTwilioNumberByAreaCode(areaCode, locationID,
   }
 }
 
+export async function purchaseSensorTwilioNumberByAreaCode(areaCode, locationID, clickupToken) {
+  return purchaseTwilioNumberByAreaCode(`${SENSOR_DEV_URL}/pa/sensor-twilio-number`, areaCode, locationID, clickupToken)
+}
+
 export async function purchaseButtonTwilioNumberByAreaCode(areaCode, locationID, clickupToken) {
-  const url = `${chatbotDevURL}/button-twilio-number`
-
-  const data = {
-    areaCode,
-    locationID,
-    clickupToken,
-    braveKey: braveAPIKey,
-  }
-
-  try {
-    const response = await axios.post(url, data)
-    return response.data
-  } catch (err) {
-    console.error(err)
-    return err.response.data.message
-  }
+  return purchaseTwilioNumberByAreaCode(`${BUTTONS_DEV_URL}/pa/buttons-twilio-number`, areaCode, locationID, clickupToken)
 }


### PR DESCRIPTION
- They were only temporarily on chatbot-dev while Reese was doing
  rapid development. The Buttons and Sensor servers is where they
  will live permanently

## Test Plan
- AWS endpoint still works as before
- Buying a Twilio number for Buttons still works as before
- Buying a Twilio number for Sensors only works if https://github.com/bravetechnologycoop/BraveSensor/pull/156 has been deployed
- The Dashboard Renamer only works if https://github.com/bravetechnologycoop/BraveSensor/pull/156 has been deployed
- The Dashboard Renamer only populates the client list with Sensors clients if https://github.com/bravetechnologycoop/BraveSensor/pull/156 has been deployed.