### PR TITLE
Make the Renamer and Twilio Phone Number purchasing/assignment better (CU-2fk3y8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Changed
 
 - Improved error messaging in Twilio Number Purchasing.
+- Improved error messaging and status display in Renamer.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Ability to use an existing Twilio phone number when adding a new Sensor to the Dashboard using the Renamer (CU-2fk3y8a).
+
 ### Removed
 
 - RadarType dropdown menu in the Renamer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Removed
+
+- RadarType dropdown menu in the Renamer.
+
 ## [1.2.0] - 2022-07-14
 
 ### Changed
-- Sensor Provisioning Guide step 6 to include maching door sensor address. 
-- Typo on the Particle CLI command and its corresponding image. 
+
+- Sensor Provisioning Guide step 6 to include maching door sensor address.
+- Typo on the Particle CLI command and its corresponding image.
 - Labels on the Twilio Number Purchasing page for more clarification. (CU-2mdcnzt)
 
 ## [1.1.0] - 2022-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- Improved error messaging in Twilio Number Purchasing.
+
 ### Added
 
 - Ability to use an existing Twilio phone number when adding a new Sensor to the Dashboard using the Renamer (CU-2fk3y8a).

--- a/src/components/Renamer/DashboardConfiguration.jsx
+++ b/src/components/Renamer/DashboardConfiguration.jsx
@@ -9,8 +9,6 @@ function DashboardConfiguration(props) {
     dashboardCheck,
     displayName,
     changeDisplayName,
-    radarType,
-    changeRadarType,
     client,
     changeClient,
     clickupToken,
@@ -51,18 +49,6 @@ function DashboardConfiguration(props) {
             </Form.Group>
 
             <Form.Group>
-              <Form.Label>Radar Type</Form.Label>
-              <Form.Control value={radarType} onChange={x => changeRadarType(x.target.value)} as="select">
-                <option id="Innosent" value="Innosent" key="Innosent">
-                  Innosent
-                </option>
-                <option id="XeThru" value="XeThru" key="XeThru">
-                  XeThru
-                </option>
-              </Form.Control>
-            </Form.Group>
-
-            <Form.Group>
               <Form.Label>Select Client</Form.Label>
               <DropdownList itemList={clientList} item={client} changeItem={changeClient} loading={clientLoading} title="Client" />
             </Form.Group>
@@ -94,8 +80,6 @@ function DashboardConfiguration(props) {
 
 DashboardConfiguration.propTypes = {
   dashboardCheck: PropTypes.bool.isRequired,
-  radarType: PropTypes.string.isRequired,
-  changeRadarType: PropTypes.func.isRequired,
   client: PropTypes.string.isRequired,
   changeClient: PropTypes.func.isRequired,
   clickupToken: PropTypes.string.isRequired,

--- a/src/components/Renamer/DashboardConfiguration.jsx
+++ b/src/components/Renamer/DashboardConfiguration.jsx
@@ -17,6 +17,9 @@ function DashboardConfiguration(props) {
     password,
     changePassword,
     environment,
+    displayTwilioPhoneNumber,
+    twilioPhoneNumber,
+    changeTwilioPhoneNumber,
   } = props
 
   const [clientList, setClientList] = useState([])
@@ -54,7 +57,7 @@ function DashboardConfiguration(props) {
             </Form.Group>
 
             <Form.Group>
-              <Form.Label>State Machine</Form.Label>
+              <Form.Label>Is Firmware State Machine</Form.Label>
               <Form.Control as="select" value={stateMachine} onChange={x => changeStateMachine(JSON.parse(x.target.value))}>
                 <option id="true" key="true" value="true">
                   True
@@ -66,9 +69,16 @@ function DashboardConfiguration(props) {
             </Form.Group>
 
             <Form.Group>
-              <Form.Label>Password</Form.Label>
+              <Form.Label>PA Dashboard Renamer Password (in 1Password)</Form.Label>
               <Form.Control value={password} onChange={x => changePassword(x.target.value)} type="password" placeholder="Password" />
             </Form.Group>
+
+            {displayTwilioPhoneNumber && (
+              <Form.Group>
+                <Form.Label>Existing Twilio Number</Form.Label>
+                <Form.Control value={twilioPhoneNumber} onChange={x => changeTwilioPhoneNumber(x.target.value)} />
+              </Form.Group>
+            )}
           </Form>
         </Card.Body>
       </Card>
@@ -90,6 +100,9 @@ DashboardConfiguration.propTypes = {
   password: PropTypes.string.isRequired,
   changePassword: PropTypes.func.isRequired,
   environment: PropTypes.string.isRequired,
+  twilioPhoneNumber: PropTypes.string.isRequired,
+  changeTwilioPhoneNumber: PropTypes.func.isRequired,
+  displayTwilioPhoneNumber: PropTypes.bool.isRequired,
 }
 
 export default DashboardConfiguration

--- a/src/components/general/PhoneNumberStatus.jsx
+++ b/src/components/general/PhoneNumberStatus.jsx
@@ -7,7 +7,13 @@ import React from 'react'
  *
  * States:
  *
- *  - status === 'idle' returns nothing
+ *  - status === 'none' returns nothing
+ *
+ *  - status === 'idle' returns grey badge with 'Waiting' as text
+ *
+ *  - status === 'notSelected' returns grey badge with 'Not Selected' as text
+ *
+ *  - status === 'fail' returns red badge with 'Failed' as text
  *
  *  - status === 'waiting' returns loading spinner
  *
@@ -25,9 +31,12 @@ function PhoneNumberStatus(props) {
   }
 
   const { status } = props
-  if (status === 'idle') {
+  if (status === 'none') {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <></>
+  }
+  if (status === 'idle') {
+    return <Badge bg="secondary">Waiting</Badge>
   }
   if (status === 'waiting') {
     return <Spinner animation="border" />

--- a/src/components/general/PhoneNumberStatus.jsx
+++ b/src/components/general/PhoneNumberStatus.jsx
@@ -35,6 +35,12 @@ function PhoneNumberStatus(props) {
   if (checkValidPhoneNumber(status)) {
     return <Badge bg="success">{status}</Badge>
   }
+  if (status === 'notSelected') {
+    return <Badge bg="secondary">Not Selected</Badge>
+  }
+  if (status === 'fail') {
+    return <Badge bg="danger">Failed</Badge>
+  }
   return <Badge bg="danger">Error</Badge>
 }
 

--- a/src/utilities/DatabaseFunctions.js
+++ b/src/utilities/DatabaseFunctions.js
@@ -57,7 +57,6 @@ export async function getSensorClients(environment, clickupToken) {
  * @param {string} twilioNumber       Twilio number for the location
  * @param {boolean} stateMachineBool  whether the location uses a state machine or not
  * @param {string} clientID           Unique clientID for location
- * @param {string} radarType          Innosent or XeThru radar type ('innosent' or 'xethru')
  * @param {string} environment        which server to insert a sensor location to.
  * @return {Promise<boolean>}         true if successful, false if not
  */
@@ -70,7 +69,6 @@ export async function insertSensorLocation(
   twilioNumber,
   stateMachineBool,
   clientID,
-  radarType,
   environment,
 ) {
   let baseUrl = ''
@@ -98,7 +96,6 @@ export async function insertSensorLocation(
     twilioNumber,
     stateMachineBool,
     clientID,
-    radarType,
   }
 
   try {

--- a/src/views/Renamer.jsx
+++ b/src/views/Renamer.jsx
@@ -170,7 +170,7 @@ export default function Renamer(props) {
         modifyDeviceValues.deviceName = locationID
       }
     } else {
-      setParticleStatus('notSelected')
+      setClickupStatus('notSelected')
     }
     if (twilioCheck) {
       setTwilioStatus('waiting')

--- a/src/views/Renamer.jsx
+++ b/src/views/Renamer.jsx
@@ -46,7 +46,6 @@ export default function Renamer(props) {
   const [client, setClient] = useState('')
   const [stateMachine, setStateMachine] = useState(true)
   const [displayName, setDisplayName] = useState('')
-  const [radarType, setRadarType] = useState('')
   const [password, setPassword] = useState('')
 
   // modifier functions for passing hooks.
@@ -64,10 +63,6 @@ export default function Renamer(props) {
 
   function changeDisplayName(newName) {
     setDisplayName(newName)
-  }
-
-  function changeRadarType(newRadar) {
-    setRadarType(newRadar)
   }
 
   function changeTwilioAreaCode(city) {
@@ -191,7 +186,6 @@ export default function Renamer(props) {
         twilioPhoneNumber,
         stateMachine,
         client,
-        radarType,
         environment,
       )
       const clickupStatusChange = await modifyClickupTaskStatus(selectedDevice.clickupTaskID, ClickupStatuses.addedToDatabase.name, clickupToken)
@@ -312,8 +306,6 @@ export default function Renamer(props) {
             </div>
             <DashboardConfiguration
               dashboardCheck={dashboardCheck}
-              radarType={radarType}
-              changeRadarType={changeRadarType}
               client={client}
               changeClient={changeClient}
               clickupToken={clickupToken}

--- a/src/views/TwilioPurchasing.jsx
+++ b/src/views/TwilioPurchasing.jsx
@@ -14,7 +14,7 @@ function TwilioPurchasing(props) {
   const [areaCode, setAreaCode] = useState('')
   const [locationID, setLocationID] = useState('')
   const [formLock, setFormLock] = useState(false)
-  const [registrationStatus, setRegistrationStatus] = useState('idle')
+  const [registrationStatus, setRegistrationStatus] = useState('none')
   const [history, setHistory] = useState(retTwilioHistory())
   const [errorMessage, setErrorMessage] = useState('')
 

--- a/src/views/TwilioPurchasing.jsx
+++ b/src/views/TwilioPurchasing.jsx
@@ -16,6 +16,7 @@ function TwilioPurchasing(props) {
   const [formLock, setFormLock] = useState(false)
   const [registrationStatus, setRegistrationStatus] = useState('idle')
   const [history, setHistory] = useState(retTwilioHistory())
+  const [errorMessage, setErrorMessage] = useState('')
 
   useEffect(() => {
     console.log(history)
@@ -31,25 +32,27 @@ function TwilioPurchasing(props) {
   async function handleSubmit(event) {
     event.preventDefault()
     setRegistrationStatus('waiting')
+    setErrorMessage('')
     setFormLock(true)
 
-    let twilioNumber
+    let response
 
     if (deviceType === 'sensor') {
-      twilioNumber = await purchaseSensorTwilioNumberByAreaCode(areaCode, locationID, environment, clickupToken)
+      response = await purchaseSensorTwilioNumberByAreaCode(areaCode, locationID, environment, clickupToken)
     } else if (deviceType === 'buttons') {
-      twilioNumber = await purchaseButtonTwilioNumberByAreaCode(areaCode, locationID, environment, clickupToken)
+      response = await purchaseButtonTwilioNumberByAreaCode(areaCode, locationID, environment, clickupToken)
     }
 
-    if (twilioNumber.message === 'success') {
-      setRegistrationStatus(twilioNumber.phoneNumber)
+    if (response.message === 'success') {
+      setRegistrationStatus(response.phoneNumber)
     } else {
       setRegistrationStatus('error')
+      setErrorMessage(response)
     }
 
     pushHistory({
-      friendlyName: twilioNumber.friendlyName,
-      phoneNumber: twilioNumber.phoneNumber,
+      friendlyName: response.friendlyName,
+      phoneNumber: response.phoneNumber,
       deviceType,
       environment,
     })
@@ -89,6 +92,7 @@ function TwilioPurchasing(props) {
             <h4>
               <PhoneNumberStatus status={registrationStatus} />
             </h4>
+            <p style={{ color: 'red' }}>{errorMessage}</p>
           </div>
         </Form>
       </div>


### PR DESCRIPTION
- Allow the use of an existing Twilio number in the Renamer
- Display API error message on the screen if failed to buy a Twilio number in the Renamer and in the Twilio Number Purchasing
- Tweaked the way the status badges are updated in the Renamer to, I hope, be less confusing when renaming multiple Sensors in a row
- Removed "Radar Type" from the Renamer because we don't use it anymore

## Test Plan
- :heavy_check_mark: Deploy to dev
- :heavy_check_mark: Renamer
   - :heavy_check_mark: Select a Device. Check "Register to Dashboard". Do not see the Radar Type dropdown menu
   - :heavy_check_mark: Select a Device. Check only "Register to Dashboard". See the "Exising Twilio Number" text box
   - :heavy_check_mark: Select a Device. Check "Register to Dashboard" and "Purchase a Twilio Number". Do not see the "Existing Twilio Number" text box
   - :heavy_check_mark: Select a Device. Check and recheck the boxes to see the status badges change from "NotSelected" if unchecked to "Waiting" if checked and back again
   - :heavy_check_mark: Select a real device and try selecting different combinations of checkboxes and running the renamer and checking that what you expect happens 
   - :heavy_check_mark: After successfully buying a Twilio number, then rename one with an existing Twilio number, then buy a new one again. Make sure that each one was given the expected number and not one of the previously assigned ones
- :heavy_check_mark: Twilio Number Purchasing
   - :heavy_check_mark: Fail to buy a number and see the error message
   - :heavy_check_mark: After a failure, successfully buy a number and see the error message goes away