### PR TITLE
Explicitly add Boron to the Particle Product in Activator (CU-860qkqnnn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Fixes
+
+- Activator explicitly adds the Boron Device to the selected Product (CU-860qkqnnn).
+
 ## [1.5.0] - 2023-02-07
 
 ### Security

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,6 +2,7 @@
   "high": true,
   "allowlist": [
     "GHSA-ww39-953v-wcq6",
-    "GHSA-rp65-9cf3-cjxr"
+    "GHSA-rp65-9cf3-cjxr",
+    "GHSA-hc6q-2mpp-qw7j"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^16.0.0",
         "history": "^5.3.0",
         "http-proxy-middleware": "^2.0.4",
-        "particle-api-js": "^9.1.2",
+        "particle-api-js": "^9.4.1",
         "pdfkit": "^0.13.0",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dotenv": "^16.0.0",
     "history": "^5.3.0",
     "http-proxy-middleware": "^2.0.4",
-    "particle-api-js": "^9.1.2",
+    "particle-api-js": "^9.4.1",
     "pdfkit": "^0.13.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",

--- a/src/utilities/ParticleFunctions.js
+++ b/src/utilities/ParticleFunctions.js
@@ -92,6 +92,25 @@ export async function getProducts(token) {
 }
 
 /**
+ * addDeviceToProduct: Add a device to a product or move device out of quarantine.
+ * @async
+ * @param {string} deviceID  the device id of the target Particle device.
+ * @param {string} product   the product family ID of the target Particle device.
+ * @param {string} token Particle access token.
+ */
+export async function addDeviceToProduct(deviceId, product, token) {
+  try {
+    await particle.addDeviceToProduct({
+      deviceId,
+      product,
+      auth: token,
+    })
+  } catch (err) {
+    console.error(`Error in adding device '${deviceId}' to product '${product}'`, err)
+  }
+}
+
+/**
  * getDeviceInfo: makes a GET request to the Particle server to get a device's
  * deviceID and ICCID.
  * @async

--- a/src/views/Activator.jsx
+++ b/src/views/Activator.jsx
@@ -14,13 +14,7 @@ import ActivatedDevice from '../utilities/ActivatedDevice'
 import ParticleSettings from '../utilities/ParticleSettings'
 import { createTaskInSensorTracker } from '../utilities/ClickupFunctions'
 
-const { getDeviceInfo } = require('../utilities/ParticleFunctions')
-
-const { activateDeviceSIM } = require('../utilities/ParticleFunctions')
-
-const { changeDeviceName } = require('../utilities/ParticleFunctions')
-
-const { verifyDeviceRegistration } = require('../utilities/ParticleFunctions')
+const { activateDeviceSIM, addDeviceToProduct, changeDeviceName, getDeviceInfo, verifyDeviceRegistration } = require('../utilities/ParticleFunctions')
 
 // CSS Styles
 const styles = {
@@ -193,6 +187,11 @@ function Activator(props) {
 
       // change device ID
       setDeviceID(deviceInfo.deviceID)
+
+      // add device to product on Particle
+      await addDeviceToProduct(deviceInfo.deviceID, productID, particleToken)
+
+      // change device name on Particle
       const rename = await changeDeviceName(deviceInfo.deviceID, productID, newDeviceName, particleToken)
 
       if (rename) {


### PR DESCRIPTION
- For some reason, the Activator started acting up today and would get a 404 "Device not in product" error when Johnny tried to use it. So now, the Activator explicitly does it
- Also updated the Particle JS API to the latest version, which should be only a minor change. Hopefully this doesn't break other things

## Test Plan
- [x] Deploy to dev
- [x] Login to PA
- [x] Add a new Boron that was having this issue to Production
   - [x] All of the steps appear green in PA
   - [x] The Boron is in Particle Console with the correct name and serial number
   - [x] The Boron connects and updates to the latest firmware
- [x] Use the PA Renamer to rename the Sensor a couple of times to make sure that it still works
- [x] Use the PA Device lookup to look up the newly added Sensor 
- [x] Susan use this to add real Sensors to production 