### PR TITLE
Added 'Message Clients' page (CU-w9bcb5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- `messageClientsForProduct` helper function in utilities/TwilioFunctions.js (CU-w9bcb5).
+- Message Clients page in views/MessageClients.jsx (CU-w9bcb5).
+
 ## [2.0.0] - 2023-12-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ the code was deployed.
 
 ### Added
 
-- `messageClientsForProduct` helper function in utilities/TwilioFunctions.js (CU-w9bcb5).
-- Message Clients page in views/MessageClients.jsx (CU-w9bcb5).
+- Message Clients page and interaction with PA API call /pa/message-clients (CU-w9bcb5).
 
 ## [2.0.0] - 2023-12-01
 

--- a/src/upper-level-components/Frame.jsx
+++ b/src/upper-level-components/Frame.jsx
@@ -20,6 +20,7 @@ import TwilioPurchasing from '../views/TwilioPurchasing'
 import HomeView from '../views/HomeView'
 import DeviceManager from '../views/DeviceManager'
 import SensorProvisioningGuide from '../views/SensorProvisioningGuide'
+import MessageClients from '../views/MessageClients'
 
 import ClickupLogo from '../graphics/ClickupLogo.svg'
 import ParticleLogo from '../graphics/ParticleLogo.svg'
@@ -153,6 +154,7 @@ function Frame(props) {
       changeClickupUserName={changeClickupUserName}
     />
   )
+  viewConfig[Pages.messageClients.displayName] = <MessageClients environment={environment} />
 
   const currentPageInfo = Object.values(Pages).find(page => {
     return page.displayName === viewState

--- a/src/upper-level-components/Pages.js
+++ b/src/upper-level-components/Pages.js
@@ -109,6 +109,15 @@ const Pages = {
     },
     loginBadge: false,
   },
+  messageClients: {
+    displayName: 'Message Clients',
+    paths: ['/message-clients'],
+    authorizations: {
+      clickup: false,
+      particle: false,
+    },
+    loginBadge: false,
+  },
 }
 
 export default Pages

--- a/src/utilities/TwilioFunctions.js
+++ b/src/utilities/TwilioFunctions.js
@@ -98,3 +98,55 @@ export async function purchaseButtonTwilioNumberByAreaCode(areaCode, locationID,
 
   return purchaseTwilioNumberByAreaCode(`${baseUrl}/pa/buttons-twilio-number`, areaCode, locationID, environment, googleIdToken)
 }
+
+/**
+ * messageClientsForProduct: send text message to client for specified product with Twilio
+ * @param {string} product       the product which the message concerns (e.g., 'buttons', 'sensor')
+ * @param {string} environment   the phase of deployment to send the message to
+ * @param {string} twilioMessage the message to send
+ * @param {string} googleIdToken Google ID token
+ * @return {Promise<{status: string, twilioMessage: string, successfullyMessaged: array, failedToMessage: array}|string>}
+ *     Returns information about the clients that were messaged, and weren't messaged. Every
+ *   item in successfullyMessaged and failedToMessage is an object containing to, from, clientId,
+ *   and clientDisplayName attributes, all strings. To and from are phone numbers.
+ */
+export async function messageClientsForProduct(product, environment, twilioMessage, googleIdToken) {
+  let baseUrl = ''
+
+  if (product === 'buttons') {
+    if (environment === Environments.dev.name) {
+      baseUrl = BUTTONS_DEV_URL
+    } else if (environment === Environments.prod.name) {
+      baseUrl = BUTTONS_PROD_URL
+    } else if (environment === Environments.staging.name) {
+      baseUrl = BUTTONS_STAGING_URL
+    } else {
+      throw new Error('No environment found')
+    }
+  } else if (product === 'sensor') {
+    if (environment === Environments.dev.name) {
+      baseUrl = SENSOR_DEV_URL
+    } else if (environment === Environments.prod.name) {
+      baseUrl = SENSOR_PROD_URL
+    } else if (environment === Environments.staging.name) {
+      baseUrl = SENSOR_STAGING_URL
+    } else {
+      throw new Error('No environment found')
+    }
+  } else {
+    throw new Error('No product found')
+  }
+
+  const data = {
+    twilioMessage,
+    googleIdToken,
+  }
+
+  const response = await axios.post(`${baseUrl}/pa/message-clients`, data)
+
+  if (response.status !== 200) {
+    throw new Error(`Got status ${response.status}`)
+  }
+
+  return response.data
+}

--- a/src/utilities/TwilioFunctions.js
+++ b/src/utilities/TwilioFunctions.js
@@ -137,6 +137,10 @@ export async function messageClientsForProduct(product, environment, twilioMessa
     throw new Error('No product found')
   }
 
+  if (twilioMessage === '') {
+    throw new Error('No message provided')
+  }
+
   const data = {
     twilioMessage,
     googleIdToken,

--- a/src/views/HomeView.jsx
+++ b/src/views/HomeView.jsx
@@ -36,6 +36,12 @@ function HomeView() {
           <Card.Title style={styles.fontSize}>Authentication</Card.Title>
           <Card.Text>The PA has three main means of authentication.</Card.Text>
           <Card.Text>
+            <b>Google</b>: Use your Brave Google account upon opening PA.
+            <hr />
+            Necessary for Use Of:
+            <ul>
+              <li>Everything!</li>
+            </ul>
             <b>Particle</b>: Use Brave&apos;s Particle Login.
             <hr />
             Necessary for Use Of:
@@ -247,8 +253,6 @@ function HomeView() {
           <Card.Text>
             <b>Product</b>: Buttons
             <br />
-            <b>Authentication</b>: Clickup
-            <br />
             <br />
             <b>Requirements</b>:
             <ul>
@@ -278,8 +282,6 @@ function HomeView() {
           <Card.Text>
             <b>Product</b>: Buttons and Sensor
             <br />
-            <b>Authentication</b>: Clickup
-            <br />
             <br />
             <b>Requirements</b>:
             <ul>
@@ -296,6 +298,28 @@ function HomeView() {
             <hr />
             The Twilio Number Purchasing tool is meant for rapid acquiring of a Twilio phone number for either Sensor or Buttons production devices.
             It takes the most basic inputs from the user and returns a phone number.
+          </Card.Text>
+        </Card>
+      </div>
+
+      <div style={styles.cardBoundary}>
+        <Card style={styles.cardInterior}>
+          <Card.Title style={styles.cardTitle}>Message Clients</Card.Title>
+          <Card.Text>
+            <b>Product</b>: Buttons and Sensor
+            <br />
+            <br />
+            <b>Requirements</b>:
+            <ul>
+              <li>A message for active Buttons or Sensor clients</li>
+            </ul>
+            <b>Effects</b>:
+            <ul>
+              <li>Sends the submitted message to active Buttons or Sensor clients using Twilio</li>
+            </ul>
+            <hr />
+            The Message Clients tool is meant for deployments or notifications of downtime. Use this tool sparingly, as most clients expect text
+            messages to be alerts.
           </Card.Text>
         </Card>
       </div>

--- a/src/views/MessageClients.jsx
+++ b/src/views/MessageClients.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import { useCookies } from 'react-cookie'
+import PropTypes from 'prop-types'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
+import { messageClientsForProduct } from '../utilities/TwilioFunctions'
+
+function MessageClients(props) {
+  const { environment } = props
+
+  const [product, setProduct] = useState('Buttons')
+  const [twilioMessage, setTwilioMessage] = useState('')
+  const [statusMessage, setStatusMessage] = useState('')
+  const [successfullyMessaged, setSuccessfullyMessaged] = useState([])
+  const [failedToMessage, setFailedToMessage] = useState([])
+
+  const [cookies] = useCookies(['googleIdToken'])
+
+  const messageClientsContainerStyles = {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    alignContent: 'flex-start',
+    maxWidth: '1600px',
+    height: '100vh',
+  }
+
+  const summaryColumnStyles = {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    alignItems: 'stretch',
+    height: '100%',
+    overflowY: 'scroll',
+  }
+
+  const twilioTraceObjectStyles = {
+    marginBottom: '4px',
+    borderRadius: '8px',
+    border: '1px solid #e0e0e0',
+    padding: '8px',
+  }
+
+  const monospaceStyles = {
+    margin: '0 2px',
+    borderRadius: '4px',
+    padding: '2px',
+    backgroundColor: '#e8e8e8',
+    fontFamily: 'monospace',
+    fontSize: '10pt',
+  }
+
+  async function submitMessageClients() {
+    try {
+      setStatusMessage('Waiting for response...')
+      setSuccessfullyMessaged([])
+      setFailedToMessage([])
+
+      const data = await messageClientsForProduct(product.toLowerCase(), environment, twilioMessage, cookies.googleIdToken)
+
+      setStatusMessage(`Status: ${data.status}.`)
+      setSuccessfullyMessaged(data.successfullyMessaged)
+      setFailedToMessage(data.failedToMessage)
+    } catch (error) {
+      setStatusMessage(error.message)
+    }
+  }
+
+  function makeTwilioTraceObjectElement(twilioTraceObject) {
+    return (
+      <div style={twilioTraceObjectStyles}>
+        <p style={{ margin: '0' }}>
+          Client: <b>{twilioTraceObject.clientDisplayName}</b>
+          <br />
+          Client ID: <span style={monospaceStyles}>{twilioTraceObject.clientId}</span>
+          <br />
+          To: <span style={monospaceStyles}>{twilioTraceObject.to}</span>
+          <br />
+          From: <span style={monospaceStyles}>{twilioTraceObject.from}</span>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={messageClientsContainerStyles}>
+      <div style={{ width: '40ch', padding: 20 }}>
+        <h3>Message Clients</h3>
+        <p>
+          Only clients considered active will be messaged. Active clients are those that are sending vitals and alerts, and have at least one location
+          (button or sensor) that is sending vitals and alerts.
+        </p>
+        <Form.Group>
+          <Form.Label>Product</Form.Label>
+          <Form.Select value={product} onChange={e => setProduct(e.target.value)}>
+            <option>Buttons</option>
+            <option>Sensor</option>
+          </Form.Select>
+          <Form.Text className="text-muted">
+            Environment <b>{environment}</b> is selected. Is this right?
+          </Form.Text>
+        </Form.Group>
+        <Form.Group>
+          <Form.Label style={{ marginTop: '10px' }}>Text Message</Form.Label>
+          <Form.Control as="textarea" rows={3} value={twilioMessage} onChange={e => setTwilioMessage(e.target.value)} />
+        </Form.Group>
+        <Button variant="primary" style={{ marginTop: '10px' }} onClick={submitMessageClients}>
+          Submit
+        </Button>
+        <p style={{ color: '#808080' }}>{statusMessage}</p>
+      </div>
+      <div style={{ flexGrow: '1', padding: 20 }}>
+        {successfullyMessaged.length === 0 ? (
+          ''
+        ) : (
+          <>
+            <h3>Successfully Messaged</h3>
+            <div style={summaryColumnStyles}>{successfullyMessaged.map(makeTwilioTraceObjectElement)}</div>
+          </>
+        )}
+      </div>
+      <div style={{ flexGrow: '1', padding: 20 }}>
+        {failedToMessage.length === 0 ? (
+          ''
+        ) : (
+          <>
+            <h3>Failed to message</h3>
+            <div style={summaryColumnStyles}>{failedToMessage.map(makeTwilioTraceObjectElement)}</div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+MessageClients.propTypes = { environment: PropTypes.string.isRequired }
+
+export default MessageClients


### PR DESCRIPTION
Hoo-wee, it's been a long series of PRs to get to this point.

This is the cherry on top of the message clients feature: the PA page that interacts with the Buttons/Sensor PA API call to message clients.

This page interacts with the /pa/message-clients PA API call in the buttons and sensor servers, switching the server based on the environment (development, production, staging).
It includes a dropdown menu to select which product to message clients for; i.e., sensors, or buttons.
The interaction with the PA API call is done within a helper function, in utilities/TwilioFunctions.js.
Google is used to authorize this PA API call; if you are not logged into PA with your Brave Google account, then not only will you not be able to access this page, but the PA API call will reject your request.

Visually, there are columns for "successfully messaged" clients, and "failed to message" clients.
These columns will appear when the successfullyMessaged and failedToMessage state variables are populated, which occurs after the PA API call is complete.
These columns are scrollable, if they are populated with enough clients to overflow the height of the window.

Test Plan:
- [x] Passes Travis tests
- [x] Send test text message to development buttons, sensor
- [x] Deploy to development PA; repeat above