### PR TITLE
Removed Google log ins for Local Deployments git push (CU-86dtx3b7n)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,6 @@ REACT_APP_SENSOR_PROD_URL=https://website.com
 # URL for dev server (npm start) for local development
 REACT_APP_DOMAIN=http://localhost:port
 
+# App environment for logins
+# Use local to disable google login for local development
+REACT_APP_ENV=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Added new environment value `REACT_APP_ENV` to disable google login if local (CU-86dtx3b7n).
+
+### Changed
+
+- Updated `App.js` to disable google login if `REACT_APP_ENV` in `.env` is local (CU-86dtx3b7n).
+- Updated `.env.example` to reflect new environment `REACT_APP_ENV` (CU-86dtx3b7n).
+
 ## [3.0.0] - 2024-07-02
 
 ### Added

--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,19 @@ import PageNotFound from './upper-level-components/PageNotFound'
 import GoogleLoginScreen from './upper-level-components/GoogleLoginScreen'
 
 function App() {
-  const [googlePayload, setGooglePayload] = useState(null)
+  const isLocal = process.env.REACT_APP_ENV === 'local'
+  let state = null
+
+  if (isLocal) {
+    state = { name: 'Local' }
+  }
+
+  const [googlePayload, setGooglePayload] = useState(state)
 
   // If not logged in, display the Google login screen instead.
   // NOTE: The GoogleLoginScreen component checks cookies for an existing session,
   //   and will call onLogin in the case that the previous session is recent enough.
-  if (googlePayload == null) {
+  if (googlePayload == null && !isLocal) {
     // eslint-disable-next-line react/jsx-filename-extension
     return <GoogleLoginScreen onLogin={payload => setGooglePayload(payload)} />
   }


### PR DESCRIPTION
- added if statements that will disable google log ins if the dev environment is local
- dev environment is determined by env value in .env file

Test Plan:

- [x] passes linter
- [x] runs properly in local and dev